### PR TITLE
Add "Integrity Failure" message.  Improve startup sequence

### DIFF
--- a/Audio.h
+++ b/Audio.h
@@ -7,6 +7,7 @@ void readWelcome();
 void readMilepost(char []);
 void readNoDefects();
 void readDetectorOut();
+void readIntegretyFailure();
 // Read the track
 void readTrack(int track);
 // read a single digit

--- a/Detector.h
+++ b/Detector.h
@@ -3,7 +3,7 @@ char MILEPOST[]="36.2";
 
 // The distance between the first input and 
 // the second input (in scale feet)
-int DISTANCE = 80;
+int DISTANCE = 40;
 
 // Percent of trains that should trigger a defect.
 int DEFECTPERCENT=2;

--- a/HotBoxDetectorSimulator.ino
+++ b/HotBoxDetectorSimulator.ino
@@ -181,6 +181,11 @@ void readDetectorOut(){
     speakjet.print(detector_out);
 }
 
+void readIntegretyFailure(){
+    speakJetWait();
+    speakjet.print(integrety_failure);
+}
+
 // read a single digit
 void speakdigit(char digit)
 {

--- a/HotBoxDetectorSimulator.ino
+++ b/HotBoxDetectorSimulator.ino
@@ -52,12 +52,19 @@ void setup()
   
   //Configure Reset line as an output
   pinMode(RES, OUTPUT);
+  speakJetReset();
 
   initDetector(&track1Detector,1,TRIGGER1PIN,TRIGGER2PIN);
 #ifdef DOUBLETRACK  
   initDetector(&track2Detector,2,TRIGGER3PIN,TRIGGER4PIN);
 #endif  
-  speakJetReset();
+  offline(track1Detector);
+  while(detectorActive(&track1Detector) 
+#ifdef DOUBLETRACK
+        || detectorActive(&track2Detector)
+#endif
+        ); // while any trigger is active, wait
+
 }
 
 void loop() { 
@@ -329,6 +336,16 @@ void closing(detector d){
     readNoDefects();
     readDetectorOut();
 }
+
+void offline(detector d){
+
+    //Send "Hotbox detector, milepost" to the SpeakJet module
+    readWelcome();
+    readMilepost(d.milepost);
+    readIntegretyFailure();
+    readDetectorOut();
+}
+
 
 int detectorActive(detector *d){
   

--- a/Messages.h
+++ b/Messages.h
@@ -28,6 +28,15 @@ char detector_out[] = { 20, 96, /* volume setting */
                    8,174,8,128,8,191,8,131,8,194,8,191,153,4, /* DETECTOR */
                    163,191,4, /*0ut*/
                    '\0'};
+
+// "Integrety Failure"                   
+char integrety_failure[] = { 20, 96, /* volume setting */
+                   21, 114,/* speed  setting */
+                   22, 88, /* pitch setting */ 
+                   23, 5, /* bend setting */
+                   8, 128, 8, 141, 6, 192, 128, 128,1 ,148, 191,4, /* Integrety */
+                   8, 131, 186, 6.128. 146, 1, 8, 160, 153,4, /* Failure */
+                   '\0'};
            
            // "Speed"
 char speed_string[]={ 20, 96, /* volume setting */

--- a/Messages.h
+++ b/Messages.h
@@ -34,8 +34,8 @@ char integrety_failure[] = { 20, 96, /* volume setting */
                    21, 114,/* speed  setting */
                    22, 88, /* pitch setting */ 
                    23, 5, /* bend setting */
-                   8, 128, 8, 141, 6, 192, 128, 128,1 ,148, 191,4, /* Integrety */
-                   8, 131, 186, 6.128. 146, 1, 8, 160, 153,4, /* Failure */
+                   8, 129, 8, 141, 192, 131, 178, 148, 191, 128, 4, /* Integrety */
+                   8, 186, 130, 145, 150,4, /* Failure */
                    '\0'};
            
            // "Speed"


### PR DESCRIPTION
Add "Integrity Failure" message while the detector is starting.
Prevent falling through the first sensor readings in the loop method and giving an initial false report.